### PR TITLE
Add TOC to Content README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,5 @@ Our content is:
  - Accessible
  - Findable
  - Device agnostic
+ 
+ ### [Table of Contents](table-of-contents.md)


### PR DESCRIPTION
Added TOC to the top-level README. This is to enable external designers to more easily navigate this content.

Also: note that the file "design-elements.md" is not linked to from the TOC. I'm not sure if it's out of date... But if you want people to follow the guidance in that file, please add to the TOC page.